### PR TITLE
Fixed crash on update a field with nil position.

### DIFF
--- a/Sources/LightstreamerClient/updates/ItemUpdate.swift
+++ b/Sources/LightstreamerClient/updates/ItemUpdate.swift
@@ -63,7 +63,10 @@ class ItemUpdateBase: ItemUpdate {
         }
         var res = [String:String?]()
         for fieldPos in m_changedFields {
-            res[fields[fieldPos]!] = toString(m_newValues[fieldPos] ?? nil)
+            let field = fields[fieldPos]
+            if field != nil {
+                res[field!] = toString(m_newValues[fieldPos] ?? nil)
+            }
         }
         return res
     }


### PR DESCRIPTION
I was able to catch a crash when using Lightstreamer Flutter package. I'm not an expert in Swift or inner logic of the project. But for a some reason it tries to find a field by the nil key value.